### PR TITLE
1211_complite

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -68,7 +68,7 @@ $('#new_message').on('submit', function(e){
 });
 
     var reloadMessages = function() {
-      var last_message_id = $('.message:last').data("message-id");
+      var last_message_id = $('.chat-main__message__list:last').data("message-id");
       $.ajax({
         url: "api/messages",
         type: 'get',


### PR DESCRIPTION
## 画面表示のループ処理修正

    var reloadMessages = function() {
      var last_message_id = $('.chat-main__message__list:last').data("message-id");

クラスの指定が間違っていたためクラス属性が正常に取得できずループした